### PR TITLE
(FM-6481) Fix project_name in locales config

### DIFF
--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -4,11 +4,11 @@
 gettext:
   # This is used for the name of the .pot and .po files; they will be
   # called <project_name>.pot?
-  project_name: puppet_conf
+  project_name: puppetlabs-puppet_conf
   # This is used in comments in the .pot and .po files to indicate what
   # project the files belong to and should bea little more desctiptive than
   # <project_name>
-  package_name: puppet_conf
+  package_name: puppetlabs-puppet_conf
   # The locale that the default messages in the .pot file are in
   default_locale: en
   # The email used for sending bug reports.


### PR DESCRIPTION
A project_name that does not follow the pattern
`<forge_namespace>-<module_name>` interacts poorly with Puppet's caching
of locales.