### PR TITLE
(MAINT) Dropped support for windows server 2008 R2.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,6 @@
     {
       "operatingsystem": "windows",
       "operatingsystemrelease": [
-        "2008 R2",
         "2012 R2",
         "2016",
         "2019",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
Support for Windows Server 2008 R2 was removed.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html