### PR TITLE
(MAINT) Remove references to beaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ For information on the classes and types, see the [REFERENCE.md](https://github.
 
 ## Limitations
 
-To run acceptance tests against Windows machines, ensure that the `BEAKER_password` environment variable has been set to the password of the Administrator user of the target machine.
-
 For an extensive list of supported operating systems, see [metadata.json](https://github.com/puppetlabs/puppetlabs-puppet_conf/blob/main/metadata.json)
 
 ## Development


### PR DESCRIPTION
Prior to this commit the README referenced usage of beaker.

I have removed all references to beaker as it is no longer used or relevant for our test infrastructure.