### PR TITLE
pdksync - (CAT-1366) - Fix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
   "summary": "Tasks that manipulates a puppet configuration file",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-puppet_conf",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-puppet_conf/issues",
   "dependencies": [
 
   ],


### PR DESCRIPTION
(CAT-1366) - Fix issue url from old jira to github
pdk version: `2.7.0` 
