### PR TITLE
Allow Boolean values

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -16,7 +16,7 @@
     },
     "value": {
       "description": "The value you are setting. Only required for set",
-      "type": "Optional[String[1]]"
+      "type": "Optional[Variant[String[1], Boolean]]"
     }
   }
 }

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -14,7 +14,7 @@
       "description": "The name of the config entry to set/get",
       "type": "String[1]"
     },
-     "value": {
+    "value": {
       "description": "The value you are setting. Only required for set",
       "type": "Optional[String[1]]"
     }


### PR DESCRIPTION
- tasks/init.json: fix indentation
- tasks/init.json: allow Boolean values

## Summary

Allow Boolean values.

## Additional Context

Restricting the data type to `String[1]` does not allow one to set true or false for Boolean settings, since `puppet config set` validates the given value, and strings `'true'` or `'false'` fail this validation.